### PR TITLE
fix: decrypting large files no longer hits a stale size cap

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,6 +83,13 @@ android {
     }
 }
 
+// Keeps unit tests closer to a real device's memory budget, so a decrypt path that regresses to
+// buffering the whole file (see AgeCryptoTest.largeFile_decryptsUnderConstrainedHeap_regressionFor19)
+// fails here instead of shipping.
+tasks.withType(Test).configureEach {
+    maxHeapSize = "512m"
+}
+
 repositories {
     google()
     mavenCentral()

--- a/app/src/main/java/dev/mage/age/crypto/AgeCrypto.kt
+++ b/app/src/main/java/dev/mage/age/crypto/AgeCrypto.kt
@@ -13,20 +13,8 @@ import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 
-/**
- * Thin, Android-free facade over kage's [Age] object. Kept free of Android types on purpose so it
- * can be exercised by plain-JVM unit tests (kage itself is pure JVM).
- *
- * Encryption is streaming: [encrypt] copies [InputStream] to [OutputStream] without holding the
- * whole payload in memory. Decryption is NOT — kage's [Age.decryptStream] buffers the entire
- * ciphertext internally before producing plaintext, so callers must size-guard decrypt inputs (see
- * CryptoRunner.maxDecryptInputBytes). The byte[] helpers exist only for small inputs (pasted text,
- * key material).
- *
- * Armor on decrypt is automatic: [Age.decryptStream] sniffs the
- * `-----BEGIN AGE ENCRYPTED FILE-----` header and de-armors transparently, so callers never pass an
- * armor flag when decrypting.
- */
+// Thin, Android-free facade over kage's Age object, so it can run in plain-JVM unit tests.
+// encrypt/decrypt both stream; the byte[] helpers are just for small inputs like pasted text.
 object AgeCrypto {
     /** ASCII-armor header age writes; handy for UI hints and tests. */
     const val ARMOR_HEADER: String = "-----BEGIN AGE ENCRYPTED FILE-----"

--- a/app/src/main/java/dev/mage/age/ui/CryptoRunner.kt
+++ b/app/src/main/java/dev/mage/age/ui/CryptoRunner.kt
@@ -124,12 +124,8 @@ object CryptoRunner {
             AgeCrypto.encryptBytes(recipients, text.toByteArray(Charsets.UTF_8), armor)
         }
 
-    /**
-     * Conservative largest `.age` input we should attempt to decrypt on this device. kage's decrypt
-     * is NOT streaming — `AgeFile.parse` reads the whole ciphertext into a ByteArrayOutputStream and
-     * then copies it again (`toByteArray()`), so peak memory is ~2–3× the file size. We allow up to a
-     * quarter of the heap to leave room for that copy plus the rest of the app.
-     */
+    // Guard for decrypt paths that fully buffer in memory (BackupManager's decryptBytes use).
+    // Regular file decrypt streams and doesn't need this.
     fun maxDecryptInputBytes(): Long = Runtime.getRuntime().maxMemory() / 4
 
     /** Outcome of a batch run: how many succeeded, and the source names that failed. */

--- a/app/src/main/java/dev/mage/age/ui/DecryptScreen.kt
+++ b/app/src/main/java/dev/mage/age/ui/DecryptScreen.kt
@@ -229,22 +229,6 @@ fun DecryptScreen(
                 return@launch
             }
 
-            // Guard against files too large for kage's in-memory decrypt before attempting.
-            val limit = CryptoRunner.maxDecryptInputBytes()
-            val oversized =
-                withContext(Dispatchers.IO) {
-                    inputUris.firstOrNull { (SafIO.sizeBytes(context, it) ?: 0L) > limit }
-                }
-            if (oversized != null) {
-                val name = withContext(Dispatchers.IO) { SafIO.displayName(context, oversized) } ?: "This file"
-                status =
-                    OpStatus.Error(
-                        "$name is too large to decrypt on this device (~${limit / (1024 * 1024)} MB max). " +
-                            "The age library must load the whole file into memory to decrypt.",
-                    )
-                return@launch
-            }
-
             when (mode) {
                 DecMode.PASSPHRASE -> {
                     if ((pwField?.text?.length ?: 0) == 0) {
@@ -326,8 +310,7 @@ fun DecryptScreen(
 
 private fun decryptError(t: Throwable): String {
     if (t is OutOfMemoryError) {
-        return "Not enough memory to decrypt this file on this device — it's too large for the " +
-            "age library, which loads the whole file into memory."
+        return "Not enough memory to decrypt this file on this device."
     }
     vaultInvalidatedMessage(t)?.let { return it }
     val name = t::class.simpleName ?: "Error"

--- a/app/src/test/java/dev/mage/age/crypto/AgeCryptoTest.kt
+++ b/app/src/test/java/dev/mage/age/crypto/AgeCryptoTest.kt
@@ -166,4 +166,59 @@ class AgeCryptoTest {
 
         assertArrayEquals(big, out.toByteArray())
     }
+
+    // Regression test for #19: a 470 MB file used to be rejected by a pre-flight size guard that
+    // assumed decrypt buffered the whole file. It doesn't (Age.decryptStream streams), so this
+    // decrypts one under the 512 MB test heap and checks the old guard formula really would have
+    // rejected it.
+    @Test
+    fun largeFile_decryptsUnderConstrainedHeap_regressionFor19() {
+        val id = Identities.generate()
+        val recipient = Identities.recipientOf(id)
+
+        // Explicit disk-backed dir: the default java.io.tmpdir may be a RAM-backed tmpfs, and this
+        // test writes several hundred MB of fixtures.
+        val dir = java.io.File("build/tmp/largeFileTest").apply { mkdirs() }
+        val plaintext = java.io.File.createTempFile("mage-big-plain", ".bin", dir)
+        val ciphertext = java.io.File.createTempFile("mage-big-cipher", ".age", dir)
+        val roundtrip = java.io.File.createTempFile("mage-big-out", ".bin", dir)
+        try {
+            val size = 470_000_000L
+            val chunk = ByteArray(1 shl 20) // reused 1 MiB filler, so the fixture itself stays flat
+            java.util.Random(42).nextBytes(chunk)
+            java.io.FileOutputStream(plaintext).use { out ->
+                var written = 0L
+                while (written < size) {
+                    val n = minOf(chunk.size.toLong(), size - written).toInt()
+                    out.write(chunk, 0, n)
+                    written += n
+                }
+            }
+
+            java.io.FileInputStream(plaintext).use { src ->
+                java.io.FileOutputStream(ciphertext).use { dst ->
+                    AgeCrypto.encrypt(listOf(recipient), src, dst, armor = false)
+                }
+            }
+
+            val oldGuardLimit = Runtime.getRuntime().maxMemory() / 4
+            assertTrue(
+                "old guard limit ($oldGuardLimit) should be smaller than the ciphertext " +
+                    "(${ciphertext.length()}) for this to be a real regression test",
+                oldGuardLimit < ciphertext.length(),
+            )
+
+            java.io.FileInputStream(ciphertext).use { src ->
+                java.io.FileOutputStream(roundtrip).use { dst ->
+                    AgeCrypto.decrypt(listOf(id), src, dst)
+                }
+            }
+
+            assertEquals(plaintext.length(), roundtrip.length())
+        } finally {
+            plaintext.delete()
+            ciphertext.delete()
+            roundtrip.delete()
+        }
+    }
 }


### PR DESCRIPTION
Fixes #19.

The pre-flight size guard on decrypt assumed kage's `Age.decryptStream` buffered the whole file. It hasn't since kage's own streaming fix landed. The guard and its comments were never updated after that.

Removed the guard and the stale "loads the whole file into memory" messaging. `BackupManager`'s separate guard is untouched, that path genuinely buffers (tiny identity backups only).

Added a regression test that decrypts a 470mb file under a 512mb heap and checks the old guard's formula really would have rejected it. Manually confirmed a 5gb file too. The whole unit test suite now runs under a 512mb heap ceiling so this class of regression fails locally instead of shipping.