### PR TITLE
add text encrypt/decrypt screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,12 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="application/octet-stream" />
             </intent-filter>
+            <!-- Sharing an armored age text block (e.g. from a chat app) offers Decrypt too. -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
             <!-- Also offer to open .age files directly from a file manager. No host: per Android's
                  intent-filter matching, a scheme with no authority matches content:// URIs from
                  any provider, which is what we want (Downloads, Drive, other file managers, ...);

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,6 +101,33 @@
             </intent-filter>
         </activity-alias>
 
+        <!-- Text-selection toolbar targets ("Encrypt with Mage" / "Decrypt with Mage"): select
+             text in any app, tap one of these in the selection menu, land on the Text screen with
+             that selection pre-filled. Same PendingInput plumbing as the share-sheet targets above. -->
+        <activity-alias
+            android:name=".ProcessTextEncrypt"
+            android:targetActivity=".MainActivity"
+            android:exported="true"
+            android:label="@string/process_text_encrypt">
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity-alias>
+
+        <activity-alias
+            android:name=".ProcessTextDecrypt"
+            android:targetActivity=".MainActivity"
+            android:exported="true"
+            android:label="@string/process_text_decrypt">
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity-alias>
+
         <!-- Quick Settings tile: tap to jump straight into Encrypt (phase 2). -->
         <service
             android:name=".tile.EncryptTileService"

--- a/app/src/main/java/dev/mage/age/MainActivity.kt
+++ b/app/src/main/java/dev/mage/age/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.fragment.app.FragmentActivity
 import dev.mage.age.io.IntentRouter
 import dev.mage.age.io.LaunchTarget
 import dev.mage.age.store.BiometricGate
+import dev.mage.age.ui.ClipboardGuard
 import dev.mage.age.ui.MageRoot
 import dev.mage.age.ui.theme.MageTheme
 
@@ -52,6 +53,11 @@ class MainActivity : FragmentActivity() {
                 )
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        ClipboardGuard.onForeground(this)
     }
 
     /**

--- a/app/src/main/java/dev/mage/age/io/IntentRouter.kt
+++ b/app/src/main/java/dev/mage/age/io/IntentRouter.kt
@@ -22,6 +22,7 @@ data class LaunchTarget(
 /**
  * Maps an incoming [Intent] to a [LaunchTarget]:
  *  - share-sheet aliases `.ShareEncrypt` / `.ShareDecrypt` (ACTION_SEND / SEND_MULTIPLE)
+ *  - text-selection toolbar aliases `.ProcessTextEncrypt` / `.ProcessTextDecrypt` (ACTION_PROCESS_TEXT)
  *  - opening a `.age` file (ACTION_VIEW) -> decrypt
  *  - launcher shortcuts carrying the `START_DEST` extra
  *  - plain launch -> home
@@ -32,10 +33,23 @@ object IntentRouter {
     fun route(intent: Intent?): LaunchTarget {
         if (intent == null) return LaunchTarget(LaunchTarget.Destination.HOME)
 
-        val viaDecryptAlias = intent.component?.className?.endsWith("ShareDecrypt") == true
-        val viaEncryptAlias = intent.component?.className?.endsWith("ShareEncrypt") == true
+        val className = intent.component?.className
+        val viaDecryptAlias = className?.endsWith("ShareDecrypt") == true
+        val viaEncryptAlias = className?.endsWith("ShareEncrypt") == true
 
         return when (intent.action) {
+            Intent.ACTION_PROCESS_TEXT -> {
+                // Selection toolbar hands over plain CharSequence, not EXTRA_TEXT.
+                val text = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)?.toString()
+                val dest =
+                    if (className?.endsWith("ProcessTextDecrypt") == true) {
+                        LaunchTarget.Destination.DECRYPT
+                    } else {
+                        LaunchTarget.Destination.ENCRYPT
+                    }
+                LaunchTarget(dest, sharedText = text)
+            }
+
             Intent.ACTION_SEND -> {
                 val uri = intent.parcelable<Uri>(Intent.EXTRA_STREAM)
                 val text = intent.getStringExtra(Intent.EXTRA_TEXT)

--- a/app/src/main/java/dev/mage/age/ui/ClipboardGuard.kt
+++ b/app/src/main/java/dev/mage/age/ui/ClipboardGuard.kt
@@ -1,0 +1,104 @@
+/*
+ * Mage — a modern Android GUI for age file encryption.
+ * Copyright (c) 2026 Nick Haghiri
+ */
+
+package dev.mage.age.ui
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.os.PersistableBundle
+import android.os.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.security.MessageDigest
+
+/**
+ * Copies sensitive text (decrypted plaintext, private keys) to the clipboard and clears it again
+ * ~60s later, so it doesn't linger. Android 10+ only lets a foreground app read/write the
+ * clipboard, so the clear can only run while Mage is foreground; [onForeground] catches up on a
+ * clear that was due while the app was backgrounded. Tracks a hash of what was copied, not the
+ * text itself, so a clear never wipes something newer the user copied elsewhere in the meantime.
+ */
+object ClipboardGuard {
+    private const val CLEAR_DELAY_MS = 60_000L
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var pending: Job? = null
+    private var armedDigest: ByteArray? = null
+    private var armedAt: Long = 0L
+
+    fun copySensitive(
+        context: Context,
+        label: String,
+        text: String,
+    ) {
+        val cm = context.clipboard() ?: return
+        val clip = ClipData.newPlainText(label, text)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            clip.description.extras =
+                PersistableBundle().apply {
+                    putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
+                }
+        }
+        cm.setPrimaryClip(clip)
+
+        armedDigest = sha256(text)
+        armedAt = SystemClock.elapsedRealtime()
+        pending?.cancel()
+        val appContext = context.applicationContext
+        pending =
+            scope.launch {
+                delay(CLEAR_DELAY_MS)
+                attemptClear(appContext)
+            }
+    }
+
+    /** Call from an Activity's onResume: clears an overdue armed copy missed while backgrounded. */
+    fun onForeground(context: Context) {
+        if (armedDigest != null && SystemClock.elapsedRealtime() - armedAt >= CLEAR_DELAY_MS) {
+            attemptClear(context.applicationContext)
+        }
+    }
+
+    private fun attemptClear(appContext: Context) {
+        val want = armedDigest ?: return
+        val cm = appContext.clipboard() ?: return
+        val current =
+            try {
+                cm.primaryClip
+                    ?.getItemAt(0)
+                    ?.coerceToText(appContext)
+                    ?.toString()
+            } catch (e: Exception) {
+                null
+            } ?: return
+
+        if (MessageDigest.isEqual(sha256(current), want)) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                cm.clearPrimaryClip()
+            } else {
+                cm.setPrimaryClip(ClipData.newPlainText("", ""))
+            }
+        }
+        disarm()
+    }
+
+    private fun disarm() {
+        pending?.cancel()
+        pending = null
+        armedDigest = null
+        armedAt = 0L
+    }
+
+    private fun Context.clipboard(): ClipboardManager? = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+
+    private fun sha256(s: String): ByteArray = MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
+}

--- a/app/src/main/java/dev/mage/age/ui/CryptoRunner.kt
+++ b/app/src/main/java/dev/mage/age/ui/CryptoRunner.kt
@@ -124,6 +124,14 @@ object CryptoRunner {
             AgeCrypto.encryptBytes(recipients, text.toByteArray(Charsets.UTF_8), armor)
         }
 
+    suspend fun decryptText(
+        identities: List<Identity>,
+        armoredText: String,
+    ): ByteArray =
+        withContext(Dispatchers.IO) {
+            AgeCrypto.decryptBytes(identities, armoredText.toByteArray(Charsets.UTF_8))
+        }
+
     // Guard for decrypt paths that fully buffer in memory (BackupManager's decryptBytes use).
     // Regular file decrypt streams and doesn't need this.
     fun maxDecryptInputBytes(): Long = Runtime.getRuntime().maxMemory() / 4

--- a/app/src/main/java/dev/mage/age/ui/MageRoot.kt
+++ b/app/src/main/java/dev/mage/age/ui/MageRoot.kt
@@ -10,6 +10,7 @@ package dev.mage.age.ui
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Message
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
@@ -40,6 +41,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -54,18 +56,33 @@ private enum class Dest(
     val route: String,
     val label: String,
     val icon: ImageVector,
+    // Set-once/rarely-visited destinations (Settings) live in the top-bar overflow menu instead of
+    // competing for space in the bottom nav with the screens you actually switch between often.
+    val inBottomNav: Boolean = true,
 ) {
     ENCRYPT("encrypt", "Encrypt", Icons.Filled.Lock),
     DECRYPT("decrypt", "Decrypt", Icons.Filled.LockOpen),
+    TEXT("text", "Text", Icons.AutoMirrored.Filled.Message),
     KEYS("keys", "Keys", Icons.Filled.VpnKey),
-    SETTINGS("settings", "Settings", Icons.Filled.Settings),
+    SETTINGS("settings", "Settings", Icons.Filled.Settings, inBottomNav = false),
 }
 
-/** Holds files handed in by a share/open intent so the target screen can consume them once. */
+/** Switches tabs, preserving each tab's own back stack/scroll state (bottom nav + Settings menu item). */
+private fun NavHostController.navigateTab(route: String) {
+    navigate(route) {
+        popUpTo(graph.findStartDestination().id) { saveState = true }
+        launchSingleTop = true
+        restoreState = true
+    }
+}
+
+/** Holds a share/open intent's payload so the target screen can consume it once. */
 class PendingInput(
-    initial: List<android.net.Uri>,
+    initialUris: List<android.net.Uri>,
+    initialSharedText: String? = null,
 ) {
-    var uris by mutableStateOf(initial)
+    var uris by mutableStateOf(initialUris)
+    var sharedText by mutableStateOf(initialSharedText)
 }
 
 @Composable
@@ -75,7 +92,7 @@ fun MageRoot(
     unlock: suspend () -> Boolean,
 ) {
     val navController = rememberNavController()
-    val pending = remember { PendingInput(initialTarget.fileUris) }
+    val pending = remember { PendingInput(initialTarget.fileUris, initialTarget.sharedText) }
     var showAbout by remember { mutableStateOf(false) }
     var showOverflow by remember { mutableStateOf(false) }
     val density = LocalDensity.current
@@ -83,10 +100,10 @@ fun MageRoot(
     var navBarHeight by remember { mutableStateOf(0.dp) }
 
     val start =
-        when (initialTarget.destination) {
-            LaunchTarget.Destination.DECRYPT -> Dest.DECRYPT
-            LaunchTarget.Destination.ENCRYPT -> Dest.ENCRYPT
-            LaunchTarget.Destination.HOME -> Dest.ENCRYPT
+        when {
+            initialTarget.sharedText != null -> Dest.TEXT
+            initialTarget.destination == LaunchTarget.Destination.DECRYPT -> Dest.DECRYPT
+            else -> Dest.ENCRYPT
         }
 
     val backStack by navController.currentBackStackEntryAsState()
@@ -110,6 +127,16 @@ fun MageRoot(
                     }
                     DropdownMenu(expanded = showOverflow, onDismissRequest = { showOverflow = false }) {
                         DropdownMenuItem(
+                            text = { Text("Settings") },
+                            leadingIcon = {
+                                Icon(Icons.Filled.Settings, contentDescription = null)
+                            },
+                            onClick = {
+                                showOverflow = false
+                                navController.navigateTab(Dest.SETTINGS.route)
+                            },
+                        )
+                        DropdownMenuItem(
                             text = { Text("About Mage") },
                             leadingIcon = {
                                 Icon(Icons.Filled.Info, contentDescription = null)
@@ -126,18 +153,12 @@ fun MageRoot(
         bottomBar = {
             FloatingNavBar(
                 items =
-                    Dest.entries.map { dest ->
+                    Dest.entries.filter { it.inBottomNav }.map { dest ->
                         NavBarItem(
                             label = dest.label,
                             icon = dest.icon,
                             selected = dest == currentDest,
-                            onClick = {
-                                navController.navigate(dest.route) {
-                                    popUpTo(navController.graph.findStartDestination().id) { saveState = true }
-                                    launchSingleTop = true
-                                    restoreState = true
-                                }
-                            },
+                            onClick = { navController.navigateTab(dest.route) },
                         )
                     },
                 modifier =
@@ -161,6 +182,14 @@ fun MageRoot(
                 }
                 composable(Dest.DECRYPT.route) {
                     DecryptScreen(container = container, pending = pending, unlock = unlock)
+                }
+                composable(Dest.TEXT.route) {
+                    TextScreen(
+                        container = container,
+                        pending = pending,
+                        startInDecrypt = initialTarget.destination == LaunchTarget.Destination.DECRYPT,
+                        unlock = unlock,
+                    )
                 }
                 composable(Dest.KEYS.route) {
                     KeysScreen(container = container, unlock = unlock)

--- a/app/src/main/java/dev/mage/age/ui/TextScreen.kt
+++ b/app/src/main/java/dev/mage/age/ui/TextScreen.kt
@@ -1,0 +1,500 @@
+/*
+ * Mage — a modern Android GUI for age file encryption.
+ * Copyright (c) 2026 Nick Haghiri
+ */
+
+package dev.mage.age.ui
+
+import android.widget.EditText
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import dev.mage.age.AppContainer
+import dev.mage.age.crypto.Identities
+import dev.mage.age.crypto.Passphrase
+import dev.mage.age.crypto.Recipients
+import dev.mage.age.io.ShareSheet
+import dev.mage.age.store.VaultIdentity
+import dev.mage.age.ui.components.PrimaryActionButton
+import dev.mage.age.ui.components.SecurePasswordField
+import dev.mage.age.ui.components.SegmentedButtonGroup
+import dev.mage.age.ui.components.readPasswordChars
+import kage.Identity
+import kage.Recipient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Arrays
+
+private enum class TextTopMode { HOME, ENCRYPT, DECRYPT }
+
+// Caps input/output text boxes so a long paste scrolls within the box instead of pushing the
+// action buttons off-screen below it.
+private val boundedFieldModifier = Modifier.fillMaxWidth().heightIn(max = 220.dp)
+
+/**
+ * Quick, in-memory text encrypt/decrypt: no file picker, output is always ASCII-armored so it can
+ * be pasted into chat, email, or anywhere a binary attachment is awkward. Also the landing screen
+ * for a text share into Mage (see [IntentRouter][dev.mage.age.io.IntentRouter]).
+ */
+@Composable
+fun TextScreen(
+    container: AppContainer,
+    pending: PendingInput,
+    startInDecrypt: Boolean,
+    unlock: suspend () -> Boolean,
+) {
+    val initialText = remember { pending.sharedText }
+    var mode by
+        rememberSaveable {
+            mutableStateOf(
+                when {
+                    initialText == null -> TextTopMode.HOME
+                    startInDecrypt -> TextTopMode.DECRYPT
+                    else -> TextTopMode.ENCRYPT
+                },
+            )
+        }
+
+    when (mode) {
+        TextTopMode.HOME -> {
+            TextHome(
+                onEncrypt = { mode = TextTopMode.ENCRYPT },
+                onDecrypt = { mode = TextTopMode.DECRYPT },
+            )
+        }
+
+        TextTopMode.ENCRYPT -> {
+            TextEncrypt(
+                container = container,
+                initialText = initialText,
+                unlock = unlock,
+                onClose = { mode = TextTopMode.HOME },
+            )
+        }
+
+        TextTopMode.DECRYPT -> {
+            TextDecrypt(
+                container = container,
+                initialText = initialText,
+                unlock = unlock,
+                onClose = { mode = TextTopMode.HOME },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TextHome(
+    onEncrypt: () -> Unit,
+    onDecrypt: () -> Unit,
+) {
+    Column(
+        Modifier.fillMaxSize().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            "Encrypt or decrypt a block of text, handy for chat, email, or anywhere a file " +
+                "attachment is awkward.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 24.dp),
+        )
+        PrimaryActionButton(label = "Encrypt text", busy = false, onClick = onEncrypt)
+        OutlinedButton(onClick = onDecrypt, modifier = Modifier.fillMaxWidth().padding(top = 10.dp)) {
+            Text("Decrypt text")
+        }
+    }
+}
+
+// MARK: - Encrypt
+
+private enum class TextEncMode { RECIPIENTS, PASSPHRASE }
+
+@Composable
+private fun TextEncrypt(
+    container: AppContainer,
+    initialText: String?,
+    unlock: suspend () -> Boolean,
+    onClose: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+
+    var mode by remember { mutableStateOf(TextEncMode.RECIPIENTS) }
+    var input by rememberSaveable { mutableStateOf(initialText ?: "") }
+    val chosen = remember { mutableStateListOf<String>() }
+    var recipientInput by remember { mutableStateOf("") }
+    var pwField by remember { mutableStateOf<EditText?>(null) }
+    var confirmField by remember { mutableStateOf<EditText?>(null) }
+    var showPw by remember { mutableStateOf(false) }
+    var result by remember { mutableStateOf<String?>(null) }
+    var status by remember { mutableStateOf<OpStatus>(OpStatus.Idle) }
+
+    var savedIdentities by remember { mutableStateOf<List<VaultIdentity>>(emptyList()) }
+    var savedRecipients by remember { mutableStateOf<List<dev.mage.age.store.SavedRecipient>>(emptyList()) }
+    LaunchedEffect(Unit) {
+        savedIdentities = withContext(Dispatchers.IO) { container.identities.list() }
+        savedRecipients = withContext(Dispatchers.IO) { container.recipients.list() }
+    }
+
+    fun buildRecipients(): Result<List<Recipient>> =
+        runCatching {
+            when (mode) {
+                TextEncMode.PASSPHRASE -> {
+                    val pw = readPasswordChars(pwField) ?: throw IllegalArgumentException("Enter a passphrase")
+                    val confirm = readPasswordChars(confirmField)
+                    try {
+                        require(confirm != null && pw.contentEquals(confirm)) { "Passphrases do not match" }
+                        listOf(Passphrase.recipient(pw))
+                    } finally {
+                        Arrays.fill(pw, ' ')
+                        if (confirm != null) Arrays.fill(confirm, ' ')
+                    }
+                }
+
+                TextEncMode.RECIPIENTS -> {
+                    require(chosen.isNotEmpty()) { "Add at least one recipient" }
+                    val kinds = chosen.map { Recipients.kindOf(it) }.toSet()
+                    require(Recipients.Kind.PQ !in kinds || kinds.size == 1) {
+                        "A post-quantum recipient can't be mixed with other recipients"
+                    }
+                    chosen.map { Recipients.parse(it) }
+                }
+            }
+        }
+
+    if (result != null) {
+        Column(
+            Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Encrypt text", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
+            CopyableResult(label = "Armored output", value = result!!)
+            Button(
+                onClick = {
+                    result = null
+                    input = ""
+                    chosen.clear()
+                    status = OpStatus.Idle
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text("Encrypt another") }
+            OutlinedButton(onClick = onClose, modifier = Modifier.fillMaxWidth()) { Text("Done") }
+        }
+        return
+    }
+
+    Column(
+        Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text("Encrypt text", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
+
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("Text to encrypt") },
+            minLines = 6,
+            modifier = boundedFieldModifier,
+        )
+
+        SegmentedButtonGroup(
+            options = listOf("Recipients", "Passphrase"),
+            selectedIndex = if (mode == TextEncMode.RECIPIENTS) 0 else 1,
+            onSelect = { mode = if (it == 0) TextEncMode.RECIPIENTS else TextEncMode.PASSPHRASE },
+        )
+
+        if (mode == TextEncMode.RECIPIENTS) {
+            RecipientsPicker(
+                chosen = chosen,
+                recipientInput = recipientInput,
+                onRecipientInputChange = { recipientInput = it },
+                onStatusChange = { status = it },
+                savedIdentities = savedIdentities,
+                savedRecipients = savedRecipients,
+                description =
+                    "Add the public keys of who should be able to read this message — age (age1…) or " +
+                        "SSH (ssh-ed25519 / ssh-rsa) keys.",
+            )
+        } else {
+            SecurePasswordField(label = "Passphrase", show = showPw, onToggleShow = { showPw = !showPw }, onViewCreated = { pwField = it })
+            SecurePasswordField(
+                label = "Confirm passphrase",
+                show = showPw,
+                onToggleShow = { showPw = !showPw },
+                onViewCreated = { confirmField = it },
+            )
+            GeneratePassphraseButton(pwField = pwField, confirmField = confirmField, onGenerated = { showPw = true })
+        }
+
+        if (status is OpStatus.Error) StatusBanner(status)
+
+        val busy = status is OpStatus.Working
+        PrimaryActionButton(
+            label = if (busy) "Encrypting…" else "Encrypt",
+            busy = busy,
+            enabled = input.isNotEmpty(),
+            onClick = {
+                if (!busy) {
+                    val recipients =
+                        buildRecipients().getOrElse {
+                            status = OpStatus.Error(it.message ?: "Invalid recipients")
+                            return@PrimaryActionButton
+                        }
+                    status = OpStatus.Working("Encrypting…")
+                    scope.launch {
+                        if (mode == TextEncMode.PASSPHRASE && !unlock()) {
+                            status = OpStatus.Error("Unlock cancelled")
+                            return@launch
+                        }
+                        status =
+                            runCatching { CryptoRunner.encryptText(recipients, input, armor = true) }
+                                .fold(
+                                    onSuccess = {
+                                        result = String(it, Charsets.UTF_8)
+                                        OpStatus.Idle
+                                    },
+                                    onFailure = { t ->
+                                        if (t is OutOfMemoryError) {
+                                            OpStatus.Error("Not enough memory to encrypt with a passphrase on this device.")
+                                        } else {
+                                            OpStatus.Error("Encryption failed: ${t.message ?: t}")
+                                        }
+                                    },
+                                )
+                    }
+                }
+            },
+        )
+        TextButton(onClick = onClose) { Text("Cancel") }
+    }
+}
+
+// MARK: - Decrypt
+
+private enum class DecStage { FORM, NEED_PASSPHRASE }
+
+@Composable
+private fun TextDecrypt(
+    container: AppContainer,
+    initialText: String?,
+    unlock: suspend () -> Boolean,
+    onClose: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+
+    var stage by remember { mutableStateOf(DecStage.FORM) }
+    var input by rememberSaveable { mutableStateOf(initialText ?: "") }
+    var pwField by remember { mutableStateOf<EditText?>(null) }
+    var showPw by remember { mutableStateOf(false) }
+    var result by remember { mutableStateOf<String?>(null) }
+    var status by remember { mutableStateOf<OpStatus>(OpStatus.Idle) }
+
+    suspend fun tryIdentities(): List<Identity>? {
+        if (!unlock()) return null
+        return withContext(Dispatchers.IO) { container.identities.list().map { container.identities.open(it) } }
+    }
+
+    fun decrypt(identities: List<Identity>) {
+        // Same guard BackupManager uses before its own fully-buffering decrypt: reject an oversized
+        // input before spending the memory/CPU on a scrypt pass and a second full-size byte copy.
+        if (input.length > CryptoRunner.maxDecryptInputBytes()) {
+            status = OpStatus.Error("This text is too large to decrypt on this device")
+            return
+        }
+        status = OpStatus.Working("Decrypting…")
+        scope.launch {
+            status =
+                runCatching { CryptoRunner.decryptText(identities, input) }
+                    .fold(
+                        onSuccess = {
+                            result = String(it, Charsets.UTF_8)
+                            stage = DecStage.FORM
+                            OpStatus.Idle
+                        },
+                        onFailure = { t ->
+                            if (t is OutOfMemoryError) {
+                                stage = DecStage.NEED_PASSPHRASE
+                                OpStatus.Error("Not enough memory to derive the key, the work factor is very high.")
+                            } else if (stage == DecStage.NEED_PASSPHRASE) {
+                                OpStatus.Error(decryptError(t))
+                            } else {
+                                stage = DecStage.NEED_PASSPHRASE
+                                OpStatus.Idle
+                            }
+                        },
+                    )
+        }
+    }
+
+    if (result != null) {
+        Column(
+            Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Decrypt text", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
+            CopyableResult(label = "Decrypted text", value = result!!)
+            Button(
+                onClick = {
+                    result = null
+                    input = ""
+                    stage = DecStage.FORM
+                    status = OpStatus.Idle
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text("Decrypt another") }
+            OutlinedButton(onClick = onClose, modifier = Modifier.fillMaxWidth()) { Text("Done") }
+        }
+        return
+    }
+
+    Column(
+        Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text("Decrypt text", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
+
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("Paste armored age text (-----BEGIN AGE ENCRYPTED FILE-----)") },
+            minLines = 6,
+            enabled = stage != DecStage.NEED_PASSPHRASE,
+            modifier = boundedFieldModifier,
+        )
+
+        if (stage == DecStage.NEED_PASSPHRASE) {
+            Text(
+                "No matching identity. If this was encrypted with a passphrase, enter it.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SecurePasswordField(label = "Passphrase", show = showPw, onToggleShow = { showPw = !showPw }, onViewCreated = { pwField = it })
+        }
+
+        if (status is OpStatus.Error) StatusBanner(status)
+
+        val busy = status is OpStatus.Working
+        if (stage == DecStage.NEED_PASSPHRASE) {
+            PrimaryActionButton(
+                label = if (busy) "Decrypting…" else "Decrypt with passphrase",
+                busy = busy,
+                onClick = {
+                    val chars = readPasswordChars(pwField)
+                    if (chars == null) {
+                        status = OpStatus.Error("Enter the passphrase")
+                        return@PrimaryActionButton
+                    }
+                    try {
+                        decrypt(listOf(Passphrase.identity(chars)))
+                    } finally {
+                        Arrays.fill(chars, ' ')
+                    }
+                },
+            )
+        } else {
+            PrimaryActionButton(
+                label = if (busy) "Decrypting…" else "Decrypt",
+                busy = busy,
+                enabled = input.isNotBlank(),
+                onClick = {
+                    status = OpStatus.Working("Decrypting…")
+                    scope.launch {
+                        // Opening a saved identity can throw (e.g. biometric enrollment changed and
+                        // invalidated the Keystore key) — runCatching so that surfaces as an error
+                        // instead of crashing, same as DecryptScreen's equivalent identity-opening call.
+                        runCatching { tryIdentities() }.fold(
+                            onSuccess = { identities ->
+                                when {
+                                    identities == null -> {
+                                        status = OpStatus.Error("Unlock cancelled")
+                                    }
+
+                                    identities.isEmpty() -> {
+                                        stage = DecStage.NEED_PASSPHRASE
+                                        status = OpStatus.Idle
+                                    }
+
+                                    else -> {
+                                        decrypt(identities)
+                                    }
+                                }
+                            },
+                            onFailure = { t -> status = OpStatus.Error(decryptError(t)) },
+                        )
+                    }
+                },
+            )
+        }
+        TextButton(onClick = onClose) { Text("Cancel") }
+    }
+}
+
+// MARK: - Shared
+
+@Composable
+private fun CopyableResult(
+    label: String,
+    value: String,
+) {
+    val context = LocalContext.current
+    var copied by remember { mutableStateOf(false) }
+    LaunchedEffect(copied) {
+        if (copied) {
+            kotlinx.coroutines.delay(1500)
+            copied = false
+        }
+    }
+    SectionCard(label) {
+        // Capped so a long armored blob scrolls within this field instead of pushing the
+        // Copy/Share buttons off-screen below it.
+        OutlinedTextField(
+            value = value,
+            onValueChange = {},
+            readOnly = true,
+            minLines = 6,
+            textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            modifier = boundedFieldModifier,
+        )
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                onClick = {
+                    ClipboardGuard.copySensitive(context, label, value)
+                    copied = true
+                },
+                modifier = Modifier.weight(1f),
+            ) { Text(if (copied) "Copied ✓" else "Copy") }
+            OutlinedButton(
+                onClick = { context.startActivity(ShareSheet.shareText(value)) },
+                modifier = Modifier.weight(1f),
+            ) { Text("Share") }
+        }
+    }
+}

--- a/app/src/main/java/dev/mage/age/ui/components/Expressive.kt
+++ b/app/src/main/java/dev/mage/age/ui/components/Expressive.kt
@@ -112,6 +112,10 @@ data class NavBarItem(
  * A floating, pill-shaped navigation toolbar — the expressive replacement for the bottom
  * `NavigationBar`. The selected pill shows its label; the rest are icon-only to save space. Each
  * pill is a ≥48dp tap target exposing the tab role and its selected state to TalkBack.
+ *
+ * Keep this to 3-4 frequently-used destinations: unlike Material's own `ShortNavigationBar`, pills
+ * here aren't equal-weight, so a long label on the selected pill can push the row wider than the
+ * screen. Anything visited rarely (e.g. Settings) belongs in the top-bar overflow menu instead.
  */
 @Composable
 fun FloatingNavBar(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,9 @@
     <string name="share_target_encrypt">Encrypt with Mage</string>
     <string name="share_target_decrypt">Decrypt with Mage</string>
 
+    <string name="process_text_encrypt">@string/share_target_encrypt</string>
+    <string name="process_text_decrypt">@string/share_target_decrypt</string>
+
     <string name="tile_encrypt">Encrypt</string>
 
     <string name="shortcut_encrypt_short">Encrypt</string>

--- a/app/src/test/java/dev/mage/age/ui/CryptoRunnerTextTest.kt
+++ b/app/src/test/java/dev/mage/age/ui/CryptoRunnerTextTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Mage — a modern Android GUI for age file encryption.
+ * Copyright (c) 2026 Nick Haghiri
+ *
+ * Pure-JVM test of CryptoRunner's text helpers, used by TextScreen (issue #26).
+ */
+
+package dev.mage.age.ui
+
+import dev.mage.age.crypto.Identities
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CryptoRunnerTextTest {
+    @Test
+    fun encryptText_decryptText_roundTrips() =
+        runBlocking {
+            val id = Identities.generate()
+            val recipient = Identities.recipientOf(id)
+            val message = "the quick brown fox jumps over the lazy dog"
+
+            val armored = CryptoRunner.encryptText(listOf(recipient), message, armor = true)
+            assertEquals(true, String(armored, Charsets.UTF_8).startsWith("-----BEGIN AGE ENCRYPTED FILE-----"))
+
+            val plain = CryptoRunner.decryptText(listOf(id), String(armored, Charsets.UTF_8))
+            assertArrayEquals(message.toByteArray(Charsets.UTF_8), plain)
+        }
+
+    @Test
+    fun decryptText_wrongIdentity_fails() =
+        runBlocking {
+            val id = Identities.generate()
+            val stranger = Identities.generate()
+            val recipient = Identities.recipientOf(id)
+            val armored = CryptoRunner.encryptText(listOf(recipient), "secret", armor = true)
+
+            try {
+                CryptoRunner.decryptText(listOf(stranger), String(armored, Charsets.UTF_8))
+                org.junit.Assert.fail("expected decryption with the wrong identity to throw")
+            } catch (expected: Exception) {
+                // good
+            }
+        }
+}


### PR DESCRIPTION
Fixes #26.

Adds a dedicated Text screen for encrypting and decrypting short messages without going through the file picker. Type or paste, pick recipients or a passphrase, and get back an ASCII-armored block you can copy or share straight from the app.

Besides the in-app tab, this is wired into two more entry points. Sharing text into Mage from another app now works (the existing share-sheet targets accept text/* too), and so does Android's text-selection toolbar: selecting an armored block or a plaintext message anywhere on the device offers an inline Encrypt/Decrypt with Mage option.

Copying a result uses a sensitive clipboard entry that clears itself after a minute, the same way private keys are already handled elsewhere in the app.

Settings moved out of the bottom nav and into the top-bar overflow menu, to make room for the new Text tab without crowding it.

Tested manually on-device: encrypt/decrypt round trips through recipients and passphrase modes, the share-sheet and selection-toolbar entry points, and the settings-overflow reorg.