### PR TITLE
require confirmation and unlock before deleting an identity

### DIFF
--- a/app/src/main/java/dev/mage/age/ui/IdentitiesScreen.kt
+++ b/app/src/main/java/dev/mage/age/ui/IdentitiesScreen.kt
@@ -63,6 +63,7 @@ fun IdentitiesScreen(
     var showImport by remember { mutableStateOf(false) }
     var reveal by remember { mutableStateOf<Pair<String, String>?>(null) } // label to private key
     var qrFor by remember { mutableStateOf<VaultIdentity?>(null) }
+    var pendingDelete by remember { mutableStateOf<VaultIdentity?>(null) }
 
     suspend fun reload() {
         identities = withContext(Dispatchers.IO) { container.identities.list() }
@@ -130,13 +131,7 @@ fun IdentitiesScreen(
                         }
                     }) { Text("Reveal private") }
 
-                    TextButton(onClick = {
-                        scope.launch {
-                            withContext(Dispatchers.IO) { container.identities.delete(identity.id) }
-                            reload()
-                            status = OpStatus.Success("Deleted ${identity.label}")
-                        }
-                    }) { Text("Delete") }
+                    TextButton(onClick = { pendingDelete = identity }) { Text("Delete") }
                 }
             }
         }
@@ -233,6 +228,35 @@ fun IdentitiesScreen(
 
     qrFor?.let { identity ->
         QrDialog(title = identity.label, value = identity.recipient, onDismiss = { qrFor = null })
+    }
+
+    pendingDelete?.let { identity ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Delete '${identity.label}'?") },
+            text = {
+                Text(
+                    "This can't be undone. Anything encrypted to this identity will no longer be " +
+                        "decryptable unless you have a backup.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    pendingDelete = null
+                    scope.launch {
+                        if (!unlock()) {
+                            status = OpStatus.Error("Unlock cancelled")
+                            return@launch
+                        }
+                        withContext(Dispatchers.IO) { container.identities.delete(identity.id) }
+                        reload()
+                        status = OpStatus.Success("Deleted ${identity.label}")
+                    }
+                }) { Text("Delete") }
+            },
+            dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text("Cancel") } },
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #27.

Deleting an identity happened immediately on tap, with no confirmation and no unlock check, unlike revealing a private key, which already required unlocking the vault first.

Deleting now shows a confirmation dialog first, and only proceeds after the same unlock() check the other identity operations use. That's a no-op when biometric lock isn't enabled, and a prompt when it is.

Tested manually on-device: the confirmation dialog shows the identity's label, and cancel leaves the identity untouched.